### PR TITLE
Add ESLint auto-remove unused variables and imports (eslint-plugin-unused-imports)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint/eslint-plugin'],
+  plugins: ['@typescript-eslint/eslint-plugin', 'unused-imports'],
   extends: [
     'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
@@ -21,5 +21,15 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'unused-imports/no-unused-imports': 'error',
+    'unused-imports/no-unused-vars': [
+      'error',
+      {
+        vars: 'all',
+        varsIgnorePattern: '^_',
+        args: 'after-used',
+        argsIgnorePattern: '^_',
+      },
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "jest": "^29.5.0",
     "prettier": "^3.0.0",
     "prisma": "^6.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.0.0
         version: 5.5.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.6.2)
+      eslint-plugin-unused-imports:
+        specifier: ^4.1.4
+        version: 4.1.4(@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)
       jest:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@20.19.4)(ts-node@10.9.2(@types/node@20.19.4)(typescript@5.8.3))
@@ -1775,6 +1778,15 @@ packages:
       '@types/eslint':
         optional: true
       eslint-config-prettier:
+        optional: true
+
+  eslint-plugin-unused-imports@4.1.4:
+    resolution: {integrity: sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': ^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0
+      eslint: ^9.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
         optional: true
 
   eslint-scope@5.1.1:
@@ -3601,7 +3613,7 @@ snapshots:
       express: 4.21.2
       graphql: 16.11.0
       loglevel: 1.9.2
-      lru-cache: 7.13.1
+      lru-cache: 7.18.3
       negotiator: 0.6.3
       node-abort-controller: 3.1.1
       node-fetch: 2.7.0
@@ -5462,6 +5474,12 @@ snapshots:
     optionalDependencies:
       '@types/eslint': 9.6.1
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
+
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.36.0(@typescript-eslint/parser@8.36.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.36.0(@typescript-eslint/parser@8.36.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
 
   eslint-scope@5.1.1:
     dependencies:

--- a/src/modules/users/application/commands/create-user/create-user.command-handler.ts
+++ b/src/modules/users/application/commands/create-user/create-user.command-handler.ts
@@ -10,7 +10,6 @@ import {
   UserCacheRepository,
   USER_CACHE_REPOSITORY_TOKEN,
 } from '../../ports/user-cache.repository';
-import { EventBus as AppEventBus } from '../../ports/event-bus.service';
 import { NestjsEventBusService } from '../../services/nestjs-event-bus.service';
 import { KafkaEventBusService } from '../../services/kafka-event-bus.service';
 import { User } from '../../../domain/entities/user.entity';

--- a/src/modules/users/application/commands/restore-user/restore-user.command-handler.ts
+++ b/src/modules/users/application/commands/restore-user/restore-user.command-handler.ts
@@ -12,7 +12,6 @@ import {
 import { NestjsEventBusService } from '../../services/nestjs-event-bus.service';
 import { KafkaEventBusService } from '../../services/kafka-event-bus.service';
 import { UserNotFoundException } from '../../../domain/exceptions/user-not-found/user-not-found.exception';
-import { UserRestoredDomainEvent } from '../../../domain/events/user-restored/user-restored.domain-event';
 import { User } from '../../../domain/entities/user.entity';
 
 /**

--- a/src/modules/users/domain/events/user-created/user-created.domain-event.spec.ts
+++ b/src/modules/users/domain/events/user-created/user-created.domain-event.spec.ts
@@ -47,7 +47,7 @@ describe('UserCreatedDomainEvent', () => {
       occurredAt: new Date().toISOString(),
     });
     expect(() => {
-      // @ts-expect-error
+      // @ts-expect-error: test immutability
       event.eventId = 'changed';
     }).toThrow();
   });

--- a/src/modules/users/domain/events/user-deleted/user-deleted.domain-event.spec.ts
+++ b/src/modules/users/domain/events/user-deleted/user-deleted.domain-event.spec.ts
@@ -35,7 +35,7 @@ describe('UserDeletedDomainEvent', () => {
       occurredAt: new Date().toISOString(),
     });
     expect(() => {
-      // @ts-expect-error
+      // @ts-expect-error: test immutability
       event.eventId = 'changed';
     }).toThrow();
   });

--- a/src/modules/users/domain/events/user-restored/user-restored.domain-event.spec.ts
+++ b/src/modules/users/domain/events/user-restored/user-restored.domain-event.spec.ts
@@ -35,7 +35,7 @@ describe('UserRestoredDomainEvent', () => {
       occurredAt: new Date().toISOString(),
     });
     expect(() => {
-      // @ts-expect-error
+      // @ts-expect-error: test immutability
       event.eventId = 'changed';
     }).toThrow();
   });

--- a/src/modules/users/domain/events/user-updated/user-updated.domain-event.spec.ts
+++ b/src/modules/users/domain/events/user-updated/user-updated.domain-event.spec.ts
@@ -47,7 +47,7 @@ describe('UserUpdatedDomainEvent', () => {
       occurredAt: new Date().toISOString(),
     });
     expect(() => {
-      // @ts-expect-error
+      // @ts-expect-error: test immutability
       event.eventId = 'changed';
     }).toThrow();
   });

--- a/src/modules/users/infrastructure/cache/redis/repositories/user-redis-cache.repository.ts
+++ b/src/modules/users/infrastructure/cache/redis/repositories/user-redis-cache.repository.ts
@@ -53,7 +53,7 @@ export class UserRedisCacheRepository implements UserCacheRepository {
 
     try {
       return UserRedisEntity.fromRedis(userData);
-    } catch (error) {
+    } catch {
       // If deserialization fails, remove the corrupted cache entry
       await this.delete(key);
       return null;
@@ -136,7 +136,7 @@ export class UserRedisCacheRepository implements UserCacheRepository {
         try {
           const user = UserRedisEntity.fromRedis(userData);
           userMap.set(keys[i], user);
-        } catch (error) {
+        } catch {
           // If deserialization fails, remove the corrupted cache entry
           await this.delete(keys[i]);
         }
@@ -233,7 +233,7 @@ export class UserRedisCacheRepository implements UserCacheRepository {
     try {
       const result = await this.redis.ping();
       return result === 'PONG';
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/src/shared/domain/value-objects/base.value-object.ts
+++ b/src/shared/domain/value-objects/base.value-object.ts
@@ -56,7 +56,7 @@ export abstract class BaseValueObject<T> {
 
     if (a.prototype !== b.prototype) return false;
 
-    let keys = Object.keys(a);
+    const keys = Object.keys(a);
     if (keys.length !== Object.keys(b).length) {
       return false;
     }


### PR DESCRIPTION
This PR updates the ESLint configuration to automatically detect and remove unused variables and imports using eslint-plugin-unused-imports.

- Adds eslint-plugin-unused-imports as a dev dependency
- Updates .eslintrc.js to include the plugin and rules for auto-removal
- Now, running eslint --fix or pnpm lint:fix will clean up unused variables and imports automatically

This helps keep the codebase clean, maintainable, and reduces technical debt.